### PR TITLE
ending the header line with semi colon;

### DIFF
--- a/src/DotNetTor/Http/HeaderField.cs
+++ b/src/DotNetTor/Http/HeaderField.cs
@@ -40,7 +40,7 @@ namespace DotNetTor.Http
 			var ret = Name + ":" + Value;
 			if (endWithCRLF)
 			{
-				ret += CRLF;
+                ret += $";{CRLF}";
 			}
 			return ret;
 		}


### PR DESCRIPTION
The content-length wasn't being escaped with a semi colon so I guess it didn't know how much data to pull back and as ascii uses 1 byte per char it wasn't affected? 
Not sure exactly but I think the header lines should be escaped not only with CRLF.

Let me know what you think.