### PR TITLE
setting the length to be the size of the bytes not the length of the string

### DIFF
--- a/src/DotNetTor/Http/HeaderField.cs
+++ b/src/DotNetTor/Http/HeaderField.cs
@@ -40,7 +40,7 @@ namespace DotNetTor.Http
 			var ret = Name + ":" + Value;
 			if (endWithCRLF)
 			{
-                ret += $";{CRLF}";
+                ret += CRLF;
 			}
 			return ret;
 		}

--- a/src/DotNetTor/Http/HeaderField.cs
+++ b/src/DotNetTor/Http/HeaderField.cs
@@ -40,7 +40,7 @@ namespace DotNetTor.Http
 			var ret = Name + ":" + Value;
 			if (endWithCRLF)
 			{
-				ret += CRLF;
+                ret += $";{CRLF}";
 			}
 			return ret;
 		}

--- a/src/DotNetTor/SocksPort/SocksConnection.cs
+++ b/src/DotNetTor/SocksPort/SocksConnection.cs
@@ -162,7 +162,8 @@ namespace DotNetTor.SocksPort
 				var requestString = await request.ToHttpStringAsync(ctsToken).ConfigureAwait(false);
 				ctsToken.ThrowIfCancellationRequested();
 
-				await Stream.WriteAsync(Encoding.UTF8.GetBytes(requestString), 0, requestString.Length, ctsToken).ConfigureAwait(false);
+                var bytes = Encoding.UTF8.GetBytes(requestString);
+				await Stream.WriteAsync(bytes, 0, bytes.Length, ctsToken).ConfigureAwait(false);
 				await Stream.FlushAsync(ctsToken).ConfigureAwait(false);
 				ctsToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
This makes sense to me now (ignore my last PR).
The WriteAsync was being set of 0 to length of the string which works for ascii which is 1 byte per char but as utf-8 is 2 then the byte size is greater than the length of the string.